### PR TITLE
[APP-135] Fix exception when displaying results from Serial or Parallel examples

### DIFF
--- a/example/lib/result_display.dart
+++ b/example/lib/result_display.dart
@@ -46,9 +46,7 @@ class CompositeResultDisplay extends StatelessWidget {
 
     var subResults = result.jsonMap!.values.take(3);
 
-    List<Map<String, dynamic>> results = [
-      for (Map<String, dynamic> j in subResults as Iterable<Map<String, dynamic>>) j,
-    ];
+    List<Map<String, dynamic>> results = [for (var j in subResults) j];
 
     return DefaultTabController(
       length: results.length,


### PR DESCRIPTION
Fix exception when displaying results from Serial or Parallel examples.

The replaced statement results in a

```
CastError (type 'TakeIterable<dynamic>' is not a subtype of type 'Iterable<Map<String, dynamic>>' in type cast)
```

when attempting to display the results of a Parallel or Serial scan in the demo app.

---

For quick testing, try a parallel or serial scan (from 'Other'), with the following samples: [202205091348.pdf](https://github.com/Anyline/anyline-ocr-flutter-module/files/8651840/202205091348.pdf). The scan results should display properly.