### PR TITLE
[APP-136] Enable Vertical Shipping Container example

### DIFF
--- a/example/config/VerticalContainerConfig.json
+++ b/example/config/VerticalContainerConfig.json
@@ -30,7 +30,11 @@
         "strokeWidth": 1,
         "strokeColor": "FFFFFF",
         "cornerRadius": 2,
-        "feedbackStrokeColor": "0099FF"
+        "feedbackStrokeColor": "0099FF",
+        "offset": {
+          "x": 0,
+          "y": 80
+        }
       },
       "scanFeedback": {
         "animation": "traverse_multi",

--- a/example/lib/home.dart
+++ b/example/lib/home.dart
@@ -471,6 +471,12 @@ class _HomeState extends State<Home> {
               },
             ),
             ScanButton(
+              text: 'Vertical Shipping Container',
+              onPressed: () {
+                scan(ScanMode.VerticalContainer);
+              },
+            ),
+            ScanButton(
               text: 'IBAN',
               onPressed: () {
                 scan(ScanMode.Iban);

--- a/example/lib/result_display.dart
+++ b/example/lib/result_display.dart
@@ -110,7 +110,14 @@ class ResultDetails extends StatelessWidget {
       color: Colors.white,
       child: ListView(
         children: [
-          Image.file(File(json!['imagePath'])),
+          Container(
+              child: Image.file(
+                File(json!['imagePath']),
+                fit: BoxFit.scaleDown,
+                height:
+                    240, // prevents weird display of tall images (e.g. vertical shipping containers)
+              ),
+              color: Colors.black87),
           ListView.builder(
               shrinkWrap: true,
               physics: ScrollPhysics(),

--- a/example/lib/scan_modes.dart
+++ b/example/lib/scan_modes.dart
@@ -20,6 +20,7 @@ enum ScanMode {
   VIN,
   USNR,
   ContainerShip,
+  VerticalContainer,
   Barcode,
   Document,
   CattleTag,
@@ -72,6 +73,8 @@ extension ScanModeInfo on ScanMode {
         return 'Universal Serial Number';
       case ScanMode.ContainerShip:
         return 'Container';
+      case ScanMode.VerticalContainer:
+        return 'Vertical Container';
       case ScanMode.Barcode:
         return 'Barcode';
       case ScanMode.Document:


### PR DESCRIPTION
This enables the vertical shipping container example (found under OCR examples group).

A sample to scan with:
![Screen Shot 2022-05-09 at 4 50 27 PM](https://user-images.githubusercontent.com/86795339/167436529-aa78e090-73a1-4046-9906-4ed0b6149b10.jpeg)

