### PR TITLE
[SOCA-466] Deprecate meter scan modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Add a JSON file with the proper structure and elements. The JSON config contains
 1. The license key 
 2. Options field with
 -	AnylineSDK config parameter
--	“segment”: which contains the scanModes for the UI Segment (e.g. switch between Analog and Digital) - optional
+-	“segment”: which contains the scanModes for the UI Segment (e.g. switch between Auto and Dial in Meter) - optional
 3. OCR field with (Only if you want to use the OCR module)
 -   your custom training data
 -   RegEx validation

--- a/example/config/AnalogMeterConfig.json
+++ b/example/config/AnalogMeterConfig.json
@@ -12,7 +12,7 @@
       "plugin": {
         "id": "Meter_ID",
         "meterPlugin": {
-          "scanMode": "DIGITAL_METER"
+          "scanMode": "AUTO_ANALOG_DIGITAL_METER"
         }
       },
       "cutoutConfig": {

--- a/example/config/AnalogMeterConfig.json
+++ b/example/config/AnalogMeterConfig.json
@@ -12,7 +12,7 @@
       "plugin": {
         "id": "Meter_ID",
         "meterPlugin": {
-          "scanMode": "ANALOG_METER"
+          "scanMode": "DIGITAL_METER"
         }
       },
       "cutoutConfig": {
@@ -35,21 +35,6 @@
       },
       "cancelOnResult": true
     },
-    "nativeBarcodeEnabled": true,
-    "segment": {
-      "titles": [
-        "Analog",
-        "Digital"
-      ],
-      "modes": [
-        "ANALOG_METER",
-        "DIGITAL_METER"
-      ],
-      "tintColor": "CCCCCC",
-      "offset": {
-        "x": 0,
-        "y": 400
-      }
-    }
+    "nativeBarcodeEnabled": true
   }
 }

--- a/example/config/DigitalMeterConfig.json
+++ b/example/config/DigitalMeterConfig.json
@@ -12,7 +12,7 @@
       "plugin": {
         "id": "Meter_ID",
         "meterPlugin": {
-          "scanMode": "DIGITAL_METER"
+          "scanMode": "AUTO_ANALOG_DIGITAL_METER"
         }
       },
       "cutoutConfig": {
@@ -35,21 +35,6 @@
       },
       "cancelOnResult": true
     },
-    "nativeBarcodeEnabled": true,
-    "segment": {
-      "titles": [
-        "Analog",
-        "Digital"
-      ],
-      "modes": [
-        "ANALOG_METER",
-        "DIGITAL_METER"
-      ],
-      "tintColor": "CCCCCC",
-      "offset": {
-        "x": 0,
-        "y": 400
-      }
-    }
+    "nativeBarcodeEnabled": true
   }
 }

--- a/example/config/DotMatrixConfig.json
+++ b/example/config/DotMatrixConfig.json
@@ -12,7 +12,7 @@
       "plugin": {
         "id": "Meter_ID",
         "meterPlugin": {
-          "scanMode": "DOT_MATRIX_METER"
+          "scanMode": "AUTO_ANALOG_DIGITAL_METER"
         }
       },
       "cutoutConfig": {

--- a/example/lib/home.dart
+++ b/example/lib/home.dart
@@ -24,7 +24,8 @@ class AnylineDemoApp extends StatelessWidget {
       theme: ThemeData.light().copyWith(
         scaffoldBackgroundColor: Styles.backgroundBlack,
         textTheme: GoogleFonts.montserratTextTheme(),
-        colorScheme: ColorScheme.fromSwatch().copyWith(secondary: Styles.backgroundBlack),
+        colorScheme: ColorScheme.fromSwatch()
+            .copyWith(secondary: Styles.backgroundBlack),
       ),
     );
   }
@@ -55,27 +56,24 @@ class _HomeState extends State<Home> {
   }
 
   Future<void> scan(ScanMode mode) async {
-  try {
-    Result? result = await _anylineService.scan(mode);
-    if (result != null) {
+    try {
+      Result? result = await _anylineService.scan(mode);
+      if (result != null) {
         _openResultDisplay(result);
-    }
+      }
     } catch (e, s) {
       print('$e, $s');
       showDialog(
-                    context: context,
-                    builder: (_) => AlertDialog(
-                          elevation: 0,
-                          title: FittedBox(
-                              fit: BoxFit.fitWidth,
-                              child: Text(
-                                'Error',
-                              )),
-                          content: FittedBox(
-                              fit: BoxFit.fitWidth,
-                              child: Text(
-                                  '$e, $s')),
-                        ));
+          context: context,
+          builder: (_) => AlertDialog(
+                elevation: 0,
+                title: FittedBox(
+                    fit: BoxFit.fitWidth,
+                    child: Text(
+                      'Error',
+                    )),
+                content: FittedBox(fit: BoxFit.fitWidth, child: Text('$e, $s')),
+              ));
     }
   }
 
@@ -91,30 +89,29 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     return WillPopScope(
-      onWillPop: () {
-        bool willPopScreen = _scanTabBackButtonVisible ? false : true;
-        if (_scanTabBackButtonVisible) {
-          setState(() {
-            _bottomSelectedIndex == 0
-                ? _scanTab = _buildUseCases()
-                : _resultsTab = _buildResultList();
-            _scanTabBackButtonVisible = false;
-          });
-        }
-        return Future.value(willPopScreen);
-      },
-      child: Scaffold(
-        appBar: _buildAppBar() as PreferredSizeWidget?,
-        bottomNavigationBar: _buildNavBar(),
-        body: Container(
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(20),
+        onWillPop: () {
+          bool willPopScreen = _scanTabBackButtonVisible ? false : true;
+          if (_scanTabBackButtonVisible) {
+            setState(() {
+              _bottomSelectedIndex == 0
+                  ? _scanTab = _buildUseCases()
+                  : _resultsTab = _buildResultList();
+              _scanTabBackButtonVisible = false;
+            });
+          }
+          return Future.value(willPopScreen);
+        },
+        child: Scaffold(
+          appBar: _buildAppBar() as PreferredSizeWidget?,
+          bottomNavigationBar: _buildNavBar(),
+          body: Container(
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: _buildBody(),
           ),
-          child: _buildBody(),
-        ),
-      )
-    );
+        ));
   }
 
   Widget _buildAppBar() {
@@ -553,7 +550,8 @@ class ScanButton extends StatelessWidget {
             height: double.infinity,
             width: double.infinity,
             child: Stack(
-              clipBehavior: Clip.hardEdge, alignment: Alignment.bottomLeft,
+              clipBehavior: Clip.hardEdge,
+              alignment: Alignment.bottomLeft,
               children: [
                 Positioned(
                   bottom: 10,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   ffi:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -162,7 +162,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   path_provider:
     dependency: transitive
     description:
@@ -342,7 +342,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -377,7 +377,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -391,7 +391,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
@@ -407,5 +407,5 @@ packages:
     source: hosted
     version: "0.2.0+1"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.15.0 <3.0.0"
   flutter: ">=2.10.0-0"


### PR DESCRIPTION
This makes the JSON configs for examples using the meter plugin change to the scan mode 'Auto' when previously among the following: "Digital", "Analog", and "Dot Matrix" (now marked as deprecated).

Reason: Enhancements to the training models has reached the point where 'Auto' script can already be used in place of the other three modes mentioned. Furthermore, the script files corresponding to the deprecated modes have since been removed from the resources bundle, so in order to avoid the scanner failing when attempting to load them, they should (until they themselves are removed) point to the Auto script file. 